### PR TITLE
Trying alternative simulation order.

### DIFF
--- a/include/uat/simulation.hpp
+++ b/include/uat/simulation.hpp
@@ -199,16 +199,19 @@ template <region_compatible R> auto simulate(const simulation_opts_t<R>& opts = 
                       opts.stop_criterion);
   };
 
-  do {
-    if (opts.simulation_callback)
-      opts.simulation_callback(t0, std::as_const(agents), permit_private_status_fn(safe_book));
-
+  while (true) {
     // Generate new agents
     if (opts.factory) {
       auto new_agents = opts.factory(t0, rnd());
       for (auto& agent : new_agents)
         agents.insert(std::move(agent));
     }
+
+    if (opts.simulation_callback)
+      opts.simulation_callback(t0, std::as_const(agents), permit_private_status_fn(safe_book));
+
+    if (stop())
+      break;
 
     {
       // Bid phase
@@ -297,7 +300,7 @@ template <region_compatible R> auto simulate(const simulation_opts_t<R>& opts = 
     if (data.size() > 0)
       data.pop_front();
     ++t0;
-  } while (!stop());
+  }
 }
 
 } // namespace uat


### PR DESCRIPTION
I notice a bug in the current simulation loop when choosing no_agents_t as stop condition.

Now the order is:

- simulation status callback
- factory of new agents
- bid phase
- on_* and trade callbacks
- ask phase
- check agent::stop
- check stop condition

The thing is, imagine if the factory would still generate new agents in the next iteration, however all agents in the current iteration have stopped. Since we are checking the stop condition at the end, the simulation would stop and the factore is never called. Thus, simulation is terminated before the user expects it to terminate.

I propose the following order:

- factory
- simulation status callback
- stop condition
- bid phase
- on_* and trade callbacks
- ask phase
- check agent::stop

Consequence: now when the factory provides more agents, the simulation do not stop early. However, if one chooses time_threshold as an stop condition, some agents are created but never run. But user can learn the last run iteration by checking the last call of `simulation_callback.` 